### PR TITLE
flio-jpa 서브프로젝트 초기화 및 liqbase, 로컬 개발용 MySQL 도커 초기화

### DIFF
--- a/backend/docker-local/mysql/docker-compose.yml
+++ b/backend/docker-local/mysql/docker-compose.yml
@@ -1,11 +1,12 @@
 services:
   mysql:
     image: mysql:8.4.5
-    ports: [23306:3306]
+    ports: [ 23306:3306 ]
     volumes:
       - ./volumes/data:/var/lib/mysql
       # - ./volumes/mysql.cnf:/etc/mysql.conf.d/mysql.cnf
       # - ./volumes/init.sql:/docker-entrypoint-initdb.d/init.sql
     environment:
       TZ: Asia/Seoul
+      MYSQL_DATABASE: flio
       MYSQL_ALLOW_EMPTY_PASSWORD: true

--- a/backend/flio-app/web/build.gradle.kts
+++ b/backend/flio-app/web/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 
 dependencies {
     implementation(project(":flio-core"))
+    implementation(project(":flio-jpa"))
 
     implementation(libs.spring.boot.starter.web)
     implementation(libs.spring.boot.starter.security)

--- a/backend/flio-app/web/src/main/resources/application-debug.yml
+++ b/backend/flio-app/web/src/main/resources/application-debug.yml
@@ -1,0 +1,5 @@
+spring:
+  profiles.include: jpa, jpa-debug
+
+logging.level:
+  org.springframework.security: DEBUG

--- a/backend/flio-app/web/src/main/resources/application.yml
+++ b/backend/flio-app/web/src/main/resources/application.yml
@@ -1,16 +1,11 @@
-server:
-  port: 18080
+server.port: 18080
 
 spring:
-  security:
-    oauth2:
-      resourceserver:
-        jwt:
-          # jws-algorithms: RS512                         # Trusted Alg.
-          issuer-uri: http://localhost:20080/realms/temp  #
-          jwk-set-uri: http://localhost:20080/realms/temp/protocol/openid-connect/certs
-          # public-key-location: hfds://my-key.pub        # JWK Set 공개 키 파일로 지정
-#         # audiences:                                    # aud 검증 시 대조 값
+  profiles.include: jpa
 
-logging.level:
-  org.springframework.security: DEBUG
+  security.oauth2.resourceserver.jwt:
+    issuer-uri: http://localhost:20080/realms/temp
+    jwk-set-uri: http://localhost:20080/realms/temp/protocol/openid-connect/certs
+    # jws-algorithms: RS512                         # Trusted Alg.
+    # public-key-location: hfds://my-key.pub        # JWK Set 공개 키 파일로 지정
+    # audiences:                                    # aud 검증 시 대조 값

--- a/backend/flio-jpa/build.gradle.kts
+++ b/backend/flio-jpa/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+    `spring-boot-convention`
+}
+
+dependencies {
+    implementation(libs.spring.boot.starter.data.jpa)
+    implementation(libs.mysql.connector)
+    implementation(libs.liquibase.core)
+}

--- a/backend/flio-jpa/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/backend/flio-jpa/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,34 @@
+{
+  "properties": [
+    {
+      "name": "spring.datasource.primary.jdbc-url",
+      "type": "java.lang.String",
+      "description": "JDBC connection URL for the primary datasource.",
+      "defaultValue": "jdbc:mysql://localhost:3306"
+    },
+    {
+      "name": "spring.datasource.primary.username",
+      "type": "java.lang.String",
+      "description": "Login username of the primary datasource.",
+      "defaultValue": "root"
+    },
+    {
+      "name": "spring.datasource.primary.password",
+      "type": "java.lang.String",
+      "description": "Login password of the primary datasource.",
+      "defaultValue": ""
+    },
+    {
+      "name": "spring.datasource.primary.driver-class-name",
+      "type": "java.lang.String",
+      "description": "JDBC driver class name for the primary datasource.",
+      "defaultValue": "com.mysql.cj.jdbc.Driver"
+    },
+    {
+      "name": "spring.datasource.primary.connection-init-sql",
+      "type": "java.lang.String",
+      "description": "SQL statement that will be executed when a connection is created.",
+      "defaultValue": null
+    }
+  ]
+}

--- a/backend/flio-jpa/src/main/resources/application-jpa-debug.yml
+++ b/backend/flio-jpa/src/main/resources/application-jpa-debug.yml
@@ -1,0 +1,4 @@
+spring.jpa.show-sql: true
+
+logging.level:
+  org.springframework.data: DEBUG

--- a/backend/flio-jpa/src/main/resources/application-jpa.yml
+++ b/backend/flio-jpa/src/main/resources/application-jpa.yml
@@ -1,0 +1,48 @@
+spring: # DB 공통 설정
+  sql.init.mode: never
+
+  jpa: # JPA 설정
+    open-in-view: false
+    hibernate.ddl-auto: none
+
+  # Primary DataSource 설정 (MySQL)
+  datasource.primary: &primary
+    jdbc-url: jdbc:mysql://localhost:23306/flio
+    username: root
+    password:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    connection-init-sql: "SELECT 1"
+
+  # 정의한 DataSource 를 Spring Property 에 바인딩
+  datasource:
+    <<: *primary
+    url: ${spring.datasource.primary.jdbc-url}
+
+  # 히카리 CP 풀 옵션 설정
+  # 풀의 적절한 옵션 값은 어플리케이션의 성격에 따라 다르므로, 앱에 따라 이하 값 조정 필요
+  datasource.hikari:
+    <<: *primary # 데이터소스 추가하게 되면 << 제거하고 커스텀 데이터소스 코드 추가
+    pool-name: PrimaryDbPool
+    maximum-pool-size: 10
+    max-lifetime: 1800000
+    idle-timeout: 600000
+    minimum-idle: 10
+    connection-timeout: 30000
+    keepalive-time: 300000 # DB 의 wait time out 값에 맞춰 설정할 것
+
+  # DB 형상관리 도구 설정
+  liquibase:
+    user: ${spring.datasource.primary.username}
+    password: ${spring.datasource.primary.password}
+    change-log: classpath:db/changelog/db.changelog-primary.yml
+
+# liquibase 가 귀찮을 경우 flyway 로 롤백할 예정
+#  flyway:
+#    enabled: true
+#    baseline-version: 20200000000000
+#    baseline-on-migrate: true
+#    out-of-order: true
+#    table: schema_version
+#    ignore-migration-patterns: "*:future"
+#
+#    locations: classpath:/db/migration

--- a/backend/flio-jpa/src/main/resources/db/changelog/20250604043256_baseline.sql
+++ b/backend/flio-jpa/src/main/resources/db/changelog/20250604043256_baseline.sql
@@ -1,0 +1,3 @@
+-- liquibase formatted sql
+-- changeset ShinRo:20250604043256_baseline.1
+select 'baseline'

--- a/backend/flio-jpa/src/main/resources/db/changelog/db.changelog-primary.yml
+++ b/backend/flio-jpa/src/main/resources/db/changelog/db.changelog-primary.yml
@@ -1,0 +1,3 @@
+databaseChangeLog:
+  - include:
+      file: db/changelog/20250604043256_baseline.sql

--- a/backend/gradle/libs.versions.toml
+++ b/backend/gradle/libs.versions.toml
@@ -9,6 +9,9 @@ mockito-kotlin = "5.4.0"
 spring-boot = "3.4.6"
 jackson-module = "2.19.0"
 
+mysql-connector = "9.3.0"
+flyway = "11.0.1"
+liquibase = "4.32.0"
 
 [libraries]
 # gradle 플러그인 for buildSrc
@@ -33,6 +36,10 @@ spring-boot-starter-validation = { module = "org.springframework.boot:spring-boo
 
 spring-boot-starter-security = { module = "org.springframework.boot:spring-boot-starter-security", version.ref = "spring-boot" }
 spring-boot-starter-oauth2-resource-server = { module = "org.springframework.boot:spring-boot-starter-oauth2-resource-server", version.ref = "spring-boot" }
+
+# Database
+mysql-connector = { module = "com.mysql:mysql-connector-j", version.ref = "mysql-connector" }
+liquibase-core = { module = "org.liquibase:liquibase-core", version.ref = "liquibase" }
 
 # Test - Kotlin
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }

--- a/backend/settings.gradle.kts
+++ b/backend/settings.gradle.kts
@@ -4,3 +4,4 @@ include("flio-app:web")
 include("flio-app:batch")
 
 include("flio-core")
+include("flio-jpa")


### PR DESCRIPTION
[작업내용]
- flio-jpa 서브프로젝트 초기화: flio-web, -batch 에서 사용 예정
- 공통 jpa 스프링 프로퍼티, jpa 프로젝트 내에 정의
    - 운영용 서버는 어차피 ssm 이나 다른 kv 스토리지 쓸거라 
    - 스프링 profile 베이스로 & 명시적으로 임포트했음
- Liquibase 의존성 추가
- 로컬 개발용 docker mysql 구성 추가